### PR TITLE
Use `inherits()` to ensure `tibble` or `data.table` could be used as `data` input

### DIFF
--- a/R/fspe.R
+++ b/R/fspe.R
@@ -17,7 +17,7 @@ fspe <- function(data,
 
   # ----- Input checks ------
 
-  if(!(class(data)[1] %in% c("matrix", "data.frame"))) stop("The data has to be provided as a matrix or data.frame.")
+  if(!inherits(data, c("matrix", "data.frame"))) stop("The data has to be provided as a matrix or data.frame.")
 
 
   # ----- Check identifiability ------


### PR DESCRIPTION
Many packages prepend classes to `data.frame`, so the `"data.frame"` is typically not the first class.